### PR TITLE
Småfixes för crashes

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -80,6 +80,14 @@ function expandableDivParser(box) {
     content.push(el)
   }
   let component = box.querySelector('.article-component')
+
+  if (component == null) {
+    // No article component found in the expandable div
+    let reminder = document.createElement("p")
+    reminder.innerHTML = "<strong>[insert contents of expandable box here]</strong>"
+    return reminder
+  }
+
   let parsedComponent = componentParser(component)
   content.push(parsedComponent)
   content = content.flat(Infinity)

--- a/src/parser.js
+++ b/src/parser.js
@@ -107,6 +107,12 @@ function componentParser(component) {
     return boxParser(component, 'pink')
   } else {
     let content = []
+
+    // Sometimes an article component only contains text
+    if (component.children.length == 0) {
+      content.push(distributor(component.firstChild))
+    }
+
     for (let child of component.children) {
       if (child.classList.contains('article-component')) {
         content.push(componentParser(child))


### PR DESCRIPTION
Hittade två fall då det kan krascha

1. Ifall man har en expandable div som inte innehåller en article component får man null på denna raden https://github.com/Dennis-coder/hypobot/blob/5e16e1f0eef6bd55715accd772ef9daec146acab/src/parser.js#L82

T.ex. i denna artikeln:
https://gleerupsportal.se/laromedel/impuls-1/article/850ea682-1d48-4764-a47e-f0ca1bfef5e5

2. Det kan hända att en article component endast innehåller text. Se t.ex. den gula rutan här https://gleerupsportal.se/laromedel/impuls-1/article/8526f7c9-fe3d-4d57-ac35-ca3789d53b32